### PR TITLE
Renames pylint tox env to py36-pylint for travis

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36, pylint
+envlist = py36, py36-pylint
 
 [testenv]
 install_command = pip install {opts} {packages}
@@ -7,7 +7,7 @@ commands = py.test {posargs}
 deps =
     -r{toxinidir}/test-requirements.txt
 
-[testenv:pylint]
+[testenv:py36-pylint]
 basepython = python3.6
 commands = {envpython} -m pylint {posargs:{toxinidir}/zonkylla}
 deps = pylint


### PR DESCRIPTION
This way travis will pick up pylint with normal py36 tests.