### PR TITLE
core/zonky: Adds from_dt param to get_loans

### DIFF
--- a/zonkylla/core/zonky.py
+++ b/zonkylla/core/zonky.py
@@ -256,9 +256,17 @@ class Zonky:
         return self._oauth_client.get(
             ('users', 'me', 'wallet', 'transactions'), params, headers)
 
-    def get_loans(self):
+    def get_loans(self, from_dt=None):
         """List of loans on zonky"""
-        return self._client.get(('loans', 'marketplace'))
+        params = {}
+        headers = {}
+
+        if from_dt:
+            params['datePublished__gte'] = datetime2iso(from_dt)
+
+        headers['X-Order'] = 'datePublished'
+
+        return self._client.get(('loans', 'marketplace'), params, headers)
 
     def get_loan(self, loan_id):
         """Detail of loan"""


### PR DESCRIPTION
label: feature

When reading Loans from Marketplace via API we want to filter Loans
by their published date so we can read only recent Loans.